### PR TITLE
Refactored RouteSettings

### DIFF
--- a/lib/bart/router_delegate.dart
+++ b/lib/bart/router_delegate.dart
@@ -60,7 +60,7 @@ class MenuRouterDelegate extends RouterDelegate<MenuRoutePath>
           _currentRoute = searchedRoute;
           var pageRoute = PageRouteBuilder(
               maintainState: searchedRoute.maintainState ?? true,
-              settings: searchedRoute.settings,
+              settings: settings,
               pageBuilder: (context, __, ___) {
                 if (searchedRoute.cache) {
                   if (!pageCache.containsKey(searchedRoute.path)) {


### PR DESCRIPTION
In order to recieve passed arguments 
`Navigator.of(context).pushNamed('/single_webview',
            arguments: '/calendar/index/index?id=$id');`

We need to pass `settings` not `searchedRoute.settings`